### PR TITLE
Put poppunk assign call in wrapper 

### DIFF
--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -1,8 +1,9 @@
-from PopPUNK.assign import assign_query_hdf5
 from PopPUNK.web import summarise_clusters, sketch_to_hdf5
 from PopPUNK.utils import setupDBFuncs
 import re
 import os
+
+from beebop.poppunkWrapper import PoppunkWrapper
 
 
 def hex_to_decimal(sketches_dict):
@@ -41,34 +42,8 @@ def get_clusters(hashes_list, p_hash, fs, db_paths, args):
     qNames = sketch_to_hdf5(sketches_dict, outdir)
 
     # run query assignment
-    assign_query_hdf5(
-        dbFuncs=dbFuncs,
-        ref_db=db_paths.db,
-        qNames=qNames,
-        output=outdir,
-        qc_dict=qc_dict,
-        update_db=args.assign.update_db,
-        write_references=args.assign.write_references,
-        distances=db_paths.distances,
-        threads=args.assign.threads,
-        overwrite=args.assign.overwrite,
-        plot_fit=args.assign.plot_fit,
-        graph_weights=False,
-        max_a_dist=args.assign.max_a_dist,
-        max_pi_dist=args.assign.max_pi_dist,
-        type_isolate=args.assign.type_isolate,
-        model_dir=db_paths.db,
-        strand_preserved=args.assign.strand_preserved,
-        previous_clustering=db_paths.db,
-        external_clustering=args.assign.external_clustering,
-        core=args.assign.core_only,
-        accessory=args.assign.accessory_only,
-        gpu_sketch=args.assign.gpu_sketch,
-        gpu_dist=args.assign.gpu_dist,
-        gpu_graph=args.assign.gpu_graph,
-        deviceid=args.assign.deviceid,
-        save_partial_query_graph=args.assign.save_partial_query_graph
-    )
+    wrapper = PoppunkWrapper(fs, db_paths, args, p_hash)
+    wrapper.assign_clusters(dbFuncs, qc_dict, qNames)
 
     queries_names, queries_clusters, _, _, _, _, _ = \
         summarise_clusters(outdir, args.assign.species, db_paths.db, qNames)

--- a/beebop/poppunkWrapper.py
+++ b/beebop/poppunkWrapper.py
@@ -1,3 +1,4 @@
+from PopPUNK.assign import assign_query_hdf5
 from PopPUNK.visualise import generate_visualisations
 
 
@@ -7,6 +8,36 @@ class PoppunkWrapper:
         self.db_paths = db_paths
         self.args = args
         self.p_hash = p_hash
+
+    def assign_clusters(self, dbFuncs, qc_dict, qNames):
+        assign_query_hdf5(
+            dbFuncs=dbFuncs,
+            ref_db=self.db_paths.db,
+            qNames=qNames,
+            output=self.fs.output(self.p_hash),
+            qc_dict=qc_dict,
+            update_db=self.args.assign.update_db,
+            write_references=self.args.assign.write_references,
+            distances=self.db_paths.distances,
+            threads=self.args.assign.threads,
+            overwrite=self.args.assign.overwrite,
+            plot_fit=self.args.assign.plot_fit,
+            graph_weights=False,
+            max_a_dist=self.args.assign.max_a_dist,
+            max_pi_dist=self.args.assign.max_pi_dist,
+            type_isolate=self.args.assign.type_isolate,
+            model_dir=self.db_paths.db,
+            strand_preserved=self.args.assign.strand_preserved,
+            previous_clustering=self.db_paths.db,
+            external_clustering=self.args.assign.external_clustering,
+            core=self.args.assign.core_only,
+            accessory=self.args.assign.accessory_only,
+            gpu_sketch=self.args.assign.gpu_sketch,
+            gpu_dist=self.args.assign.gpu_dist,
+            gpu_graph=self.args.assign.gpu_graph,
+            deviceid=self.args.assign.deviceid,
+            save_partial_query_graph=self.args.assign.save_partial_query_graph
+        )
 
     def create_microreact(self, cluster_no):
         generate_visualisations(


### PR DESCRIPTION
Calling PopPUNKs assign_query_hdf5() is now also done via the PoppunkWrapper to avoid having the massive function calls in the main code