### PR TITLE
Replace paths by env variables

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -127,7 +127,7 @@ jobs:
         conda activate beebop_py
         export PATH="/usr/share/miniconda/bin:$PATH"
         rqworker > rq_output.txt 2>&1 &
-        TESTING=True poetry run coverage run -m pytest
+        STORAGE_LOCATION=./tests/results DB_LOCATION=./storage/GPS_v4_references poetry run coverage run -m pytest
 
     - name: Process coverage
       working-directory: ./main

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -19,10 +19,8 @@ if not redis_host:
 app = Flask(__name__)
 redis = Redis(host=redis_host)
 
-if os.environ.get('TESTING') == 'True':
-    storageLocation = './tests/results'
-else:
-    storageLocation = './storage'
+storage_location = os.environ.get('STORAGE_LOCATION')
+database_location = os.environ.get('DB_LOCATION')
 
 
 def response_success(data):
@@ -81,16 +79,16 @@ def run_poppunk():
     project_hash = request.json['projectHash']
     q = Queue(connection=redis)
     return run_poppunk_internal(sketches, project_hash,
-                                storageLocation, redis, q)
+                                storage_location, redis, q)
 
 
-def run_poppunk_internal(sketches, project_hash, storageLocation, redis, q):
+def run_poppunk_internal(sketches, project_hash, storage_location, redis, q):
     # create FS
-    fs = PoppunkFileStore(storageLocation)
+    fs = PoppunkFileStore(storage_location)
     # read arguments
     args = get_args()
     # set database paths
-    db_paths = DatabaseFileStore('./storage/GPS_v4_references')
+    db_paths = DatabaseFileStore(database_location)
     # store json sketches in storage
     hashes_list = []
     for key, value in sketches:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mrcide/poppunk:bacpop-20
+FROM mrcide/poppunk:bacpop-36
 WORKDIR /
 
 RUN pip install poetry

--- a/docker/use
+++ b/docker/use
@@ -21,6 +21,8 @@ docker run -d --rm --name $NAME_WORKER --network=$NETWORK \
        $TAG_SHA rqworker
 docker run -d --rm --name $NAME_API --network=$NETWORK \
        --env=REDIS_HOST="$NAME_REDIS" \
+       --env=STORAGE_LOCATION="./storage" \
+       --env=DB_LOCATION="./storage/GPS_v4_references" \
        -v $VOLUME:/beebop/storage \
        -p 5000:5000 \
        $TAG_SHA


### PR DESCRIPTION
Paths to storage location and database location are now submitted by setting environment variable when starting the app/ tests:
- Running the app: STORAGE_LOCATION=./storage DB_LOCATION=./storage/GPS_v4_references
- Testing: STORAGE_LOCATION=./tests/results DB_LOCATION=./storage/GPS_v4_references
This allows easy switching between databases (ref/ full) and storage locations.