### PR TITLE
Add error handling for microreact url endpoint

### DIFF
--- a/beebop/app.py
+++ b/beebop/app.py
@@ -256,7 +256,9 @@ def generate_microreact_url_internal(microreact_api_new_url,
     if r.status_code == 500:
         return jsonify(error=response_failure({
             "error": "Wrong Token",
-            "detail": "Microreact reported Internal Server Error. Most likely Token is invalid!"
+            "detail": """
+            Microreact reported Internal Server Error.
+            Most likely Token is invalid!"""
             })), 500
     elif r.status_code == 404:
         return jsonify(error=response_failure({

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -253,7 +253,10 @@ def generate_microreact_url_internal(microreact_api_new_url,
     r = requests.post(microreact_api_new_url,
                       data=json.dumps(json_microreact),
                       headers=headers)
-    if r.status_code == 500:
+    if r.status_code == 200:
+        url = r.json()['url']
+        return jsonify(response_success({"cluster": cluster, "url": url}))
+    elif r.status_code == 500:
         return jsonify(error=response_failure({
             "error": "Wrong Token",
             "detail": """
@@ -265,9 +268,12 @@ def generate_microreact_url_internal(microreact_api_new_url,
             "error": "Resource not found",
             "detail": "Cannot reach Microreact API"
             })), 404
-    elif r.status_code == 200:
-        url = r.json()['url']
-        return jsonify(response_success({"cluster": cluster, "url": url}))
+    else:
+        return jsonify(error=response_failure({
+            "error": "Unknown error",
+            "detail": f"""Microreact API returned status code {r.status_code}.
+                Response text: {r.text}."""
+            })), 500
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,12 +74,19 @@ def test_results_microreact(client):
     p_hash = 'test_microreact_api'
     cluster = 7
     api_token = os.environ['MICROREACT_TOKEN']
+    invalid_token = 'invalid_token'
     response = client.post("/results/microreact", json={
         'projectHash': p_hash,
         'cluster': cluster,
         'apiToken': api_token})
     assert re.match("https://microreact.org/project/.*-poppunk.*",
                     read_data(response)['url'])
+    error_response = client.post("/results/microreact", json={
+        'projectHash': p_hash,
+        'cluster': cluster,
+        'apiToken': invalid_token})
+    assert json.loads(error_response.data)["error"]["status"] == "failure"
+    assert json.loads(error_response.data)["error"]["errors"][0]["error"] == "Wrong Token"
 
 
 def test_results_zip(client):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,8 +85,9 @@ def test_results_microreact(client):
         'projectHash': p_hash,
         'cluster': cluster,
         'apiToken': invalid_token})
-    assert json.loads(error_response.data)["error"]["status"] == "failure"
-    assert json.loads(error_response.data)["error"]["errors"][0]["error"] == "Wrong Token"
+    error = json.loads(error_response.data)["error"]
+    assert error["status"] == "failure"
+    assert error["errors"][0]["error"] == "Wrong Token"
 
 
 def test_results_zip(client):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -271,8 +271,8 @@ def test_generate_microreact_url_internal_API_error_404(mock_post):
                                                   cluster,
                                                   api_token,
                                                   storage_location)
-    print(result)
-    assert read_data(result[0])['error']['errors'][0]['error'] == 'Resource not found'
+    error = read_data(result[0])['error']
+    assert error['errors'][0]['error'] == 'Resource not found'
 
 
 def test_send_zip_internal(client):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -227,6 +227,7 @@ def test_get_status_internal(client):
 def test_generate_microreact_url_internal(mock_post):
     dummy_url = 'https://microreact.org/project/12345-testmicroreactapi'
     mock_post.return_value = Mock(ok=True)
+    mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         'url': dummy_url}
 
@@ -250,6 +251,28 @@ def test_generate_microreact_url_internal(mock_post):
                                                    api_token,
                                                    storage_location)
     assert read_data(result2)['data'] == {'cluster': cluster, 'url': dummy_url}
+
+
+@patch('requests.post')
+def test_generate_microreact_url_internal_API_error_404(mock_post):
+    dummy_url = 'https://microreact.org/project/12345-testmicroreactapi'
+    mock_post.return_value = Mock()
+    mock_post.return_value.status_code = 404
+    mock_post.return_value.json.return_value = {
+        'error': 'Resource not found'}
+
+    microreact_api_new_url = "https://dummy.url"
+    project_hash = 'test_microreact_api'
+    api_token = os.environ['MICROREACT_TOKEN']
+    cluster = '24'
+
+    result = app.generate_microreact_url_internal(microreact_api_new_url,
+                                                  project_hash,
+                                                  cluster,
+                                                  api_token,
+                                                  storage_location)
+    print(result)
+    assert read_data(result[0])['error']['errors'][0]['error'] == 'Resource not found'
 
 
 def test_send_zip_internal(client):


### PR DESCRIPTION
When the microreact token is invalid, the API will not return a URL. For that case, beebop now reports this as a proper formatted error message back to the frontend.