### PR TITLE
Run visualisations sequentially

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,7 +63,7 @@ jobs:
         conda install graph-tool
         conda install mandrake
         conda install rapidnj
-        sudo apt-get install libeigen3-dev
+        sudo apt-get install libeigen3-dev libegl1
         sudo apt-get install libopenblas-dev
         sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
         pip install joblib==1.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/results
 storage/poppunk_output
 node_modules
 storage/GPS_v4*
+storage/strain_*_lineage_db

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -218,7 +218,6 @@ def run_poppunk_internal(sketches: dict,
     # save p-hash with job.id in redis server
     redis.hset("beebop:hash:job:assign", p_hash, job_assign.id)
     # create visualisations
-    
     # network
     job_network = q.enqueue(visualise.network,
                             args=(p_hash,

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -218,16 +218,7 @@ def run_poppunk_internal(sketches: dict,
     # save p-hash with job.id in redis server
     redis.hset("beebop:hash:job:assign", p_hash, job_assign.id)
     # create visualisations
-    # microreact
-    job_microreact = q.enqueue(visualise.microreact,
-                               args=(p_hash,
-                                     fs,
-                                     db_paths,
-                                     args,
-                                     name_mapping),
-                               depends_on=job_assign, job_timeout=job_timeout)
-    redis.hset("beebop:hash:job:microreact", p_hash,
-               job_microreact.id)
+    
     # network
     job_network = q.enqueue(visualise.network,
                             args=(p_hash,
@@ -237,6 +228,16 @@ def run_poppunk_internal(sketches: dict,
                                   name_mapping),
                             depends_on=job_assign, job_timeout=job_timeout)
     redis.hset("beebop:hash:job:network", p_hash, job_network.id)
+    # microreact
+    job_microreact = q.enqueue(visualise.microreact,
+                               args=(p_hash,
+                                     fs,
+                                     db_paths,
+                                     args,
+                                     name_mapping),
+                               depends_on=job_network, job_timeout=job_timeout)
+    redis.hset("beebop:hash:job:microreact", p_hash,
+               job_microreact.id)
     return jsonify(response_success({"assign": job_assign.id,
                                      "microreact": job_microreact.id,
                                      "network": job_network.id}))

--- a/beebop/visualise.py
+++ b/beebop/visualise.py
@@ -91,6 +91,8 @@ def network(p_hash: str,
     assign_result = current_job.dependency.result
     network_internal(assign_result, p_hash, fs, db_paths, args, name_mapping)
 
+    return assign_result
+
 
 def network_internal(assign_result,
                      p_hash,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,7 +40,7 @@ def test_run_poppunk(client, qtbot):
     assert response.status_code == 200
     # retrieve job status
     status = client.get("/status/" + p_hash)
-    status_options = ['queued', 'started', 'finished', 'waiting']
+    status_options = ['queued', 'started', 'finished', 'waiting', 'deferred']
     assert read_data(status)['assign'] in status_options
     assert read_data(status)['microreact'] in status_options
     assert read_data(status)['network'] in status_options

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -264,7 +264,12 @@ def test_get_status_internal(client):
     redis.hset("beebop:hash:job:network", hash, job_network.id)
     result = app.get_status_internal(hash, redis)
     assert read_data(result)['status'] == 'success'
-    status_options = ['queued', 'started', 'finished', 'scheduled', 'waiting', 'deferred']
+    status_options = ['queued',
+                      'started',
+                      'finished',
+                      'scheduled',
+                      'waiting',
+                      'deferred']
     assert read_data(result)['data']['assign'] in status_options
     assert read_data(result)['data']['microreact'] in status_options
     assert read_data(result)['data']['network'] in status_options

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -191,7 +191,7 @@ def test_run_poppunk_internal(qtbot):
     worker = SimpleWorker([queue], connection=queue.connection)
     worker.work(burst=True)  # Runs enqueued job
     job_assign = Job.fetch(job_ids["assign"], connection=redis)
-    status_options = ['queued', 'started', 'finished', 'scheduled']
+    status_options = ['queued', 'started', 'finished', 'scheduled', 'deferred']
     assert job_assign.get_status() in status_options
     # saves p-hash with job id in redis
     assert read_redis("beebop:hash:job:assign",
@@ -264,7 +264,7 @@ def test_get_status_internal(client):
     redis.hset("beebop:hash:job:network", hash, job_network.id)
     result = app.get_status_internal(hash, redis)
     assert read_data(result)['status'] == 'success'
-    status_options = ['queued', 'started', 'finished', 'scheduled', 'waiting']
+    status_options = ['queued', 'started', 'finished', 'scheduled', 'waiting', 'deferred']
     assert read_data(result)['data']['assign'] in status_options
     assert read_data(result)['data']['microreact'] in status_options
     assert read_data(result)['data']['network'] in status_options


### PR DESCRIPTION
When multiple workers are available and the visualisations run in parallel, the jobs are interferring with each other and one of them will fail. Avoiding this by making the microreact job dependent on the network job.