### PR TITLE
bacpop-122 Add cluster to project response

### DIFF
--- a/beebop/app.py
+++ b/beebop/app.py
@@ -505,6 +505,7 @@ def get_project(p_hash) -> json:
         sketch = fs.input.get(sketch_hash)
         samples.append({
           "hash": sketch_hash,
+          "cluster": value["cluster"],
           "filename": placeholder_filename,
           "amr": placeholder_amr,
           "sketch": sketch})

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mrcide/poppunk:max-iter
+FROM mrcide/poppunk:master
 WORKDIR /
 
 RUN pip install poetry

--- a/spec/project.schema.json
+++ b/spec/project.schema.json
@@ -13,13 +13,16 @@
           "hash": {
             "type": "string"
           },
+          "cluster": {
+            "type": "number"
+          },
           "filename": {
             "type": "string"
           },
           "amr": { "$ref": "amr.schema.json" },
           "sketch": { "$ref": "sketch.schema.json" }
         },
-        "required": ["hash", "filename", "amr", "sketch"],
+        "required": ["hash", "filename", "amr", "sketch", "cluster"],
         "additionalProperties": false
       }
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -82,8 +82,8 @@ def test_run_poppunk(client, qtbot):
     assert project_data["hash"] == p_hash
     assert len(project_data["samples"]) == 2
     # check response data matches the generated data
-    assert project_data["samples"][0]["sketch"] == sketches["6930_8_9"]
-    assert project_data["samples"][1]["sketch"] == sketches["7622_5_91"]
+    assert project_data["samples"][0]["sketch"] == sketches["7622_5_91"]
+    assert project_data["samples"][1]["sketch"] == sketches["6930_8_9"]
 
 
 def test_results_microreact(client):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,9 @@ def test_run_poppunk(client, qtbot):
     assert len(project_data["samples"]) == 2
     # check response data matches the generated data
     assert project_data["samples"][0]["sketch"] == sketches["7622_5_91"]
+    assert project_data["samples"][0]["cluster"] == 5
     assert project_data["samples"][1]["sketch"] == sketches["6930_8_9"]
+    assert project_data["samples"][59]["cluster"] == 5
 
 
 def test_results_microreact(client):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,7 +85,7 @@ def test_run_poppunk(client, qtbot):
     assert project_data["samples"][0]["sketch"] == sketches["7622_5_91"]
     assert project_data["samples"][0]["cluster"] == 5
     assert project_data["samples"][1]["sketch"] == sketches["6930_8_9"]
-    assert project_data["samples"][59]["cluster"] == 5
+    assert project_data["samples"][1]["cluster"] == 59
 
 
 def test_results_microreact(client):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -256,14 +256,17 @@ def test_get_project(client):
     samples = data["samples"]
     assert len(samples) == 3
     assert samples[0]["hash"] == "24280624a730ada7b5bccea16306765c"
+    assert samples[0]["cluster"] == 3
     assert samples[0]["filename"] == expected_filename
     assert samples[0]["amr"] == expected_amr
     assert samples[0]["sketch"]["bbits"] == 3
     assert samples[1]["hash"] == "7e5ddeb048075ac23ab3672769bda17d"
+    assert samples[1]["cluster"] == 53
     assert samples[1]["filename"] == expected_filename
     assert samples[1]["amr"] == expected_amr
     assert samples[1]["sketch"]["bbits"] == 53
     assert samples[2]["hash"] == "f3d9b387e311d5ab59a8c08eb3545dbb"
+    assert samples[2]["cluster"] == 24
     assert samples[2]["filename"] == expected_filename
     assert samples[2]["amr"] == expected_amr
     assert samples[2]["sketch"]["bbits"] == 14


### PR DESCRIPTION
This branch just adds cluster numbers from the pickled cluster files to the project output. You can test this branch against the beebop branch bacpop-121 and see the cluster values coming back in the response when the project is loaded - however the cluster values are not currently shown in the UI as other results are not yet present. 