### PR TITLE
bacpop-129 gha cache python environment

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,7 +66,7 @@ jobs:
 
 #    - name: Install poppunk
 #      run: conda install poppunk
-# currently the latest poppunk release is missing some functions required for beebop. For now installing from source:
+#  currently the latest poppunk release is missing some functions required for beebop. For now installing from source:
 
     - name: Get poppunk source code
       uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,14 +47,14 @@ jobs:
     - name: Cache Conda env
       uses: actions/cache@v2
       with:
-        path: ${{ env.CONDA }}/envs
+        path: /usr/share/miniconda/envs/beebop_py
         key:
           # Refresh cache each day
           conda-${{ runner.os }}--${{ runner.arch }}--${{
           steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       id: cache
 
     - name: update environment

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,6 +39,24 @@ jobs:
         activate-environment: beebop_py
         channels: bioconda, conda-forge
 
+    - name: Get Date
+      id: get-date
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Restore Conda env from cache
+      uses: actions/cache@v2
+      with:
+        path: /usr/share/miniconda/envs/beebop_py
+        key:
+          # Refresh cache each day
+          conda-${{ runner.os }}--${{ runner.arch }}--${{
+          steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
+      env:
+        # Increment this value to manually reset cache.
+        CACHE_NUMBER: 2
+      id: cache
+
 #    - name: Install poppunk
 #      run: conda install poppunk
 #  currently the latest poppunk release is missing some functions required for beebop. For now installing from source:
@@ -109,24 +127,6 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         root_dir: ./main
-
-    - name: Get Date
-      id: get-date
-      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Cache Conda env
-      uses: actions/cache@v2
-      with:
-        path: /usr/share/miniconda/envs/beebop_py
-        key:
-          # Refresh cache each day
-          conda-${{ runner.os }}--${{ runner.arch }}--${{
-          steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
-      env:
-        # Increase this value to reset cache.
-        CACHE_NUMBER: 2
-      id: cache
 
     # Uncomment the next three lines to debug on failure with
     # tmate. However, don't leave them uncommented on merge as that

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -124,7 +124,7 @@ jobs:
           conda-${{ runner.os }}--${{ runner.arch }}--${{
           steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
       env:
-        # Increase this value to reset cache
+        # Increase this value to reset cache.
         CACHE_NUMBER: 2
       id: cache
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,11 +26,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: storage/GPS_v4
+        key: gps-db
+      id: cache-db
 
     - name: Download and extract GPS database
       working-directory: ./main
       run: |
         ./scripts/download_db --small storage
+      if: steps.cache-db.outputs-cache-hit != 'true'
         
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
@@ -59,7 +62,7 @@ jobs:
           steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
       env:
         # Increment this value to manually reset cache.
-        CACHE_NUMBER: 2
+        CACHE_NUMBER: 0
       id: cache-conda
 
 #    - name: Install poppunk

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Restore GPS database from cache
       uses: actions/cache@v2
       with:
-        path: storage/GPS_v4
+        path: ./main/storage/GPS_v4
         key: gps-db
       id: cache-db
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: storage/GPS_v4_references
-        key: gps-db
+        key: gps-v4-db
       id: cache-db
 
     - name: Download and extract GPS database

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,6 +39,25 @@ jobs:
         activate-environment: beebop_py
         channels: bioconda, conda-forge
 
+    - name: Get Date
+      id: get-date
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache Conda env
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.CONDA }}/envs
+        key:
+          conda-${{ runner.os }}--${{ runner.arch }}--${{
+          steps.get-date.outputs.today }}-${{
+          hashFiles('etc/example-environment-caching.yml') }}-${{ env.CACHE_NUMBER
+          }}
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
+      id: cache
+
     - name: activate environment
       run: |
         source $CONDA/etc/profile.d/conda.sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Restore GPS database from cache
       uses: actions/cache@v2
       with:
-        path: storage/GPS_v4_references
-        key: gps-v4-db
+        path: /home/runner/work/beebop_py/beebop_py/main/storage/GPS_v4_references
+        key: cache-gps-v4-db
       id: cache-db
 
     - name: Download and extract GPS database

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,6 @@ jobs:
       working-directory: ./main
       run: |
         ./scripts/download_db --small storage
-      if: steps.cache-db.outputs-cache-hit != 'true'
         
     - name: Set up Python 3.9
       uses: actions/setup-python@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,8 +78,6 @@ jobs:
     - name: install poppunk & dependencies
       working-directory: ./poppunk
       run: |
-        source $CONDA/etc/profile.d/conda.sh
-        conda activate beebop_py
         conda install graph-tool
         conda install mandrake
         conda install rapidnj

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Restore GPS database from cache
       uses: actions/cache@v2
       with:
-        path: ./main/storage/GPS_v4
+        path: storage/GPS_v4_references
         key: gps-db
       id: cache-db
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,31 +39,6 @@ jobs:
         activate-environment: beebop_py
         channels: bioconda, conda-forge
 
-    - name: Get Date
-      id: get-date
-      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Cache Conda env
-      uses: actions/cache@v2
-      with:
-        path: /usr/share/miniconda/envs/beebop_py
-        key:
-          # Refresh cache each day
-          conda-${{ runner.os }}--${{ runner.arch }}--${{
-          steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 1
-      id: cache
-
-    - name: update environment
-      run: source $CONDA/etc/profile.d/conda.sh
-      if: steps.cache.outputs-cache-hit != 'true'
-
-    - name: activate environment
-      run: conda activate beebop_py
-
 #    - name: Install poppunk
 #      run: conda install poppunk
 #  currently the latest poppunk release is missing some functions required for beebop. For now installing from source:
@@ -78,6 +53,8 @@ jobs:
     - name: install poppunk & dependencies
       working-directory: ./poppunk
       run: |
+        source $CONDA/etc/profile.d/conda.sh
+        conda activate beebop_py
         conda install graph-tool
         conda install mandrake
         conda install rapidnj
@@ -132,6 +109,24 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         root_dir: ./main
+
+    - name: Get Date
+      id: get-date
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache Conda env
+      uses: actions/cache@v2
+      with:
+        path: /usr/share/miniconda/envs/beebop_py
+        key:
+          # Refresh cache each day
+          conda-${{ runner.os }}--${{ runner.arch }}--${{
+          steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
+      env:
+        # Increase this value to reset cache
+        CACHE_NUMBER: 2
+      id: cache
 
     # Uncomment the next three lines to debug on failure with
     # tmate. However, don't leave them uncommented on merge as that

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,6 +22,11 @@ jobs:
       with: 
         path: main
 
+    - name: Restore GPS database from cache
+      uses: actions/cache@v2
+      with:
+        path: storage/GPS_v4
+
     - name: Download and extract GPS database
       working-directory: ./main
       run: |
@@ -55,7 +60,7 @@ jobs:
       env:
         # Increment this value to manually reset cache.
         CACHE_NUMBER: 2
-      id: cache
+      id: cache-conda
 
 #    - name: Install poppunk
 #      run: conda install poppunk

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,19 +49,20 @@ jobs:
       with:
         path: ${{ env.CONDA }}/envs
         key:
+          # Refresh cache each day
           conda-${{ runner.os }}--${{ runner.arch }}--${{
-          steps.get-date.outputs.today }}-${{
-          hashFiles('etc/example-environment-caching.yml') }}-${{ env.CACHE_NUMBER
-          }}
+          steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER}}
       env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        # Increase this value to reset cache
         CACHE_NUMBER: 0
       id: cache
 
+    - name: update environment
+      run: source $CONDA/etc/profile.d/conda.sh
+      if: steps.cache.outputs-cache-hit != 'true'
+
     - name: activate environment
-      run: |
-        source $CONDA/etc/profile.d/conda.sh
-        conda activate beebop_py
+      run: conda activate beebop_py
 
 #    - name: Install poppunk
 #      run: conda install poppunk

--- a/scripts/download_db
+++ b/scripts/download_db
@@ -41,6 +41,8 @@ else
     DEST_DIR=$DEST/GPS_v4_references
 fi
 
+echo "DEST_DIR is $DEST_DIR"
+
 if [ -d "$DEST_DIR" ]; then
     echo "Database already exists at $DEST"
     echo "To redownload, please remove $DEST_DIR and run $0 again"

--- a/scripts/download_db
+++ b/scripts/download_db
@@ -41,9 +41,6 @@ else
     DEST_DIR=$DEST/GPS_v4_references
 fi
 
-echo "DEST_DIR is"
-realpath $DEST_DIR
-
 if [ -d "$DEST_DIR" ]; then
     echo "Database already exists at $DEST"
     echo "To redownload, please remove $DEST_DIR and run $0 again"

--- a/scripts/download_db
+++ b/scripts/download_db
@@ -41,7 +41,8 @@ else
     DEST_DIR=$DEST/GPS_v4_references
 fi
 
-echo "DEST_DIR is $DEST_DIR"
+echo "DEST_DIR is"
+realpath $DEST_DIR
 
 if [ -d "$DEST_DIR" ]; then
     echo "Database already exists at $DEST"


### PR DESCRIPTION
This branch adds some caching to the pytest gha workflow to reduce build time. 

The bulk of the build time seemed to be in the "install poppunk and dependencies" step, so a step has been added to cache and restore the conda environment. This follows the pattern suggested [here](https://github.com/conda-incubator/setup-miniconda#caching), which refreshes the cache once per day to allow for updates to dependencies etc. Maybe this is overkill though?

I also added a step to cache and restore the GPS database, without any refresh mechanism since we don't expect that to update. The `download_db` already omitted download if the file already exists. 

Build time with these two steps is now reduced from 21-25minutes to around 11 minutes. Probably further caching we could do, but it's a start.. 