### PR TITLE
bacpop-131 Write initial output file on run, so can load sketches on get_project immediately

### DIFF
--- a/beebop/app.py
+++ b/beebop/app.py
@@ -476,8 +476,7 @@ def download_graphml_internal(p_hash: str,
 def get_project(p_hash) -> json:
     """
     [Loads all project data for a given project hash so the project can be
-    re-opened in beebop. This is in a work in progress, and only loading
-    sketch data has been implemented so far.]
+    re-opened in beebop.]
 
     :param p_hash: [identifying hash for the project]
     :return: [project data]
@@ -486,14 +485,14 @@ def get_project(p_hash) -> json:
     if job_id is None:
         return jsonify(error=response_failure({
             "error": "Project hash not found",
-            "detail": "Project hash does not have an associate job"
+            "detail": "Project hash does not have an associated job"
         }), 404
 
     try:
         sketch_clusters = get_clusters_internal(p_hash, storage_location)
     except (FileNotFoundError):
         # clusters are still being calculated - return empty samples array
-        sketch_clusters = []
+        sketch_clusters = {"values": []}
 
     fs = PoppunkFileStore(storage_location)
     samples = []

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -209,6 +209,7 @@ def run_poppunk_internal(sketches: dict,
         initial_output[i] = {
             "hash": key
         }
+    fs.ensure_output_dir_exists(p_hash)
     with open(fs.output_cluster(p_hash), 'wb') as f:
             pickle.dump(initial_output, f)
     # check connection to redis

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -482,10 +482,17 @@ def get_project(p_hash) -> json:
     :param p_hash: [identifying hash for the project]
     :return: [project data]
     """
-    # TODO: confirm project exists and return a 404 if it does not
+    job_id = redis.hget("beebop:hash:job:assign", p_hash)
+    if job_id is None:
+        return jsonify(error=response_failure({
+            "error": "Project hash not found",
+            "detail": "Project hash does not have an associate job"
+        }), 404
+
     try:
         sketch_clusters = get_clusters_internal(p_hash, storage_location)
     except (FileNotFoundError):
+        # clusters are still being calculated - return empty samples array
         sketch_clusters = []
 
     fs = PoppunkFileStore(storage_location)

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -511,17 +511,18 @@ def get_project(p_hash) -> json:
             sketch_clusters = get_clusters_internal(p_hash, storage_location)
         except (FileNotFoundError):
             # clusters are still being calculated - return empty samples array
-            sketch_clusters = {"values": []}
+            sketch_clusters = None
 
         fs = PoppunkFileStore(storage_location)
         samples = []
-        for value in sketch_clusters.values():
-            sketch_hash = value["hash"]
-            sketch = fs.input.get(sketch_hash)
-            samples.append({
-              "hash": sketch_hash,
-              "cluster": value["cluster"],
-              "sketch": sketch})
+        if sketch_clusters is not None:
+            for value in sketch_clusters.values():
+                sketch_hash = value["hash"]
+                sketch = fs.input.get(sketch_hash)
+                samples.append({
+                  "hash": sketch_hash,
+                  "cluster": value["cluster"],
+                  "sketch": sketch})
 
         return jsonify(response_success({
             "hash": p_hash,

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -511,6 +511,9 @@ def get_project(p_hash) -> json:
             sketch_clusters = get_clusters_internal(p_hash, storage_location)
         except (FileNotFoundError):
             # clusters are still being calculated - return empty samples array
+            # TODO: it would be good to also return the sketches for samples
+            # for incomplete projects, but these are not currently saved until
+            # the job completes.
             sketch_clusters = None
 
         fs = PoppunkFileStore(storage_location)

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -500,7 +500,7 @@ def get_project(p_hash) -> json:
         return jsonify(error=response_failure({
             "error": "Project hash not found",
             "detail": "Project hash does not have an associated job"
-        }), 404
+        })), 404
 
     status = get_status_internal(p_hash, redis)
 

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -482,9 +482,11 @@ def get_project(p_hash) -> json:
     :param p_hash: [identifying hash for the project]
     :return: [project data]
     """
-    sketch_clusters = get_clusters_internal(p_hash, storage_location)
-
-    # TODO: error handling
+    # TODO: confirm project exists and return a 404 if it does not
+    try:
+        sketch_clusters = get_clusters_internal(p_hash, storage_location)
+    except (FileNotFoundError):
+        sketch_clusters = []
 
     fs = PoppunkFileStore(storage_location)
     samples = []

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -203,7 +203,7 @@ def run_poppunk_internal(sketches: dict,
     # store json sketches in storage, and store an initial output_cluster file to record sample hashes for the project
     hashes_list = []
     initial_output = {}
-    for i, (key, value) in sketches:
+    for i, (key, value) in enumerate(sketches):
         hashes_list.append(key)
         fs.input.put(key, value)
         initial_output[i] = {

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -200,7 +200,8 @@ def run_poppunk_internal(sketches: dict,
     args = get_args()
     # set database paths
     db_paths = DatabaseFileStore(database_location)
-    # store json sketches in storage, and store an initial output_cluster file to record sample hashes for the project
+    # store json sketches in storage, and store an initial output_cluster file
+    # to record sample hashes for the project
     hashes_list = []
     initial_output = {}
     for i, (key, value) in enumerate(sketches):
@@ -211,7 +212,7 @@ def run_poppunk_internal(sketches: dict,
         }
     fs.ensure_output_dir_exists(p_hash)
     with open(fs.output_cluster(p_hash), 'wb') as f:
-            pickle.dump(initial_output, f)
+        pickle.dump(initial_output, f)
     # check connection to redis
     check_connection(redis)
     # submit list of hashes to redis worker
@@ -527,7 +528,7 @@ def get_project(p_hash) -> json:
                      }
             # Cluster may not have been assigned yet
             if "cluster" in value:
-              sample["cluster"] = value["cluster"]
+                sample["cluster"] = value["cluster"]
             samples.append(sample)
 
         return jsonify(response_success({

--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -76,7 +76,8 @@ def get_clusters(hashes_list: list,
             "cluster": cluster
         }
 
-    # save result to retrieve when reloading project results
+    # save result to retrieve when reloading project results - this overwrites the initial output file written before
+    # the assign job ran
     with open(fs.output_cluster(p_hash), 'wb') as f:
         pickle.dump(result, f)
 

--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -76,8 +76,9 @@ def get_clusters(hashes_list: list,
             "cluster": cluster
         }
 
-    # save result to retrieve when reloading project results - this overwrites the initial output file written before
-    # the assign job ran
+    # save result to retrieve when reloading project results - this
+    # overwrites the initial output file written before the assign
+    # job ran
     with open(fs.output_cluster(p_hash), 'wb') as f:
         pickle.dump(result, f)
 

--- a/beebop/filestore.py
+++ b/beebop/filestore.py
@@ -73,6 +73,14 @@ class PoppunkFileStore:
         """
         return str(PurePath(self.output_base, p_hash))
 
+    def ensure_output_dir_exists(self, p_hash) -> void:
+        """
+        :param p_hash: [project hash]
+        """
+        outdir = self.output(p_hash)
+        if not os.path.exists(outdir):
+            os.mkdir(outdir)
+
     def output_cluster(self, p_hash) -> str:
         """
         :param p_hash: [project hash]

--- a/beebop/filestore.py
+++ b/beebop/filestore.py
@@ -73,7 +73,7 @@ class PoppunkFileStore:
         """
         return str(PurePath(self.output_base, p_hash))
 
-    def ensure_output_dir_exists(self, p_hash) -> void:
+    def ensure_output_dir_exists(self, p_hash) -> None:
         """
         :param p_hash: [project hash]
         """

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mrcide/poppunk:bacpop-133
+FROM mrcide/poppunk:master
 WORKDIR /
 
 RUN pip install poetry

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mrcide/poppunk:master
+FROM mrcide/poppunk:bacpop-133
 WORKDIR /
 
 RUN pip install poetry

--- a/tests/generate_visualisation_input.py
+++ b/tests/generate_visualisation_input.py
@@ -20,9 +20,8 @@ def hex_to_decimal(sketches_dict):
 storageLocation = './tests/files'
 p_hash = 'unit_test_visualisations'
 fs = PoppunkFileStore(storageLocation)
+fs.ensure_output_dir_exists(p_hash)
 outdir = fs.output(p_hash)
-if not os.path.exists(outdir):
-    os.mkdir(outdir)
 db_paths = DatabaseFileStore('./storage/GPS_v4_references')
 args = get_args()
 qc_dict = {'run_qc': False}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,6 +91,15 @@ def test_run_poppunk(client, qtbot):
     assert project_data["status"]["network"] == "finished"
 
 
+def test_project_not_found(client):
+    response = client.get("/project/not_a_hash")
+    assert response.status_code == 404
+    error = json.loads(response.data)["error"]
+    assert error["status"] == "failure"
+    assert error["errors"][0]["error"] == "Project hash not found"
+    assert error["errors"][0]["detail"] == "Project hash does not have an associated job"
+
+
 def test_results_microreact(client):
     p_hash = 'test_microreact_api'
     cluster = 7

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -94,10 +94,11 @@ def test_run_poppunk(client, qtbot):
 def test_project_not_found(client):
     response = client.get("/project/not_a_hash")
     assert response.status_code == 404
-    error = json.loads(response.data)["error"]
-    assert error["status"] == "failure"
-    assert error["errors"][0]["error"] == "Project hash not found"
-    assert error["errors"][0]["detail"] == "Project hash does not have an associated job"
+    response = json.loads(response.data)["error"]
+    assert response["status"] == "failure"
+    err = response["errors"][0]
+    assert err["error"] == "Project hash not found"
+    assert err["detail"] == "Project hash does not have an associated job"
 
 
 def test_results_microreact(client):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -230,6 +230,7 @@ def test_run_poppunk_internal(qtbot):
         initial_output = pickle.load(f)
         assert initial_output[0]["hash"] == 'e868c76fec83ee1f69a95bd27b8d5e76'
         assert initial_output[1]["hash"] == 'f3d9b387e311d5ab59a8c08eb3545dbb'
+
     # wait for assign job to be finished
     def assign_status_finished():
         job = Job.fetch(job_ids["assign"], connection=redis)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -224,7 +224,11 @@ def test_run_poppunk_internal(qtbot):
     # saves p-hash with job id in redis
     assert read_redis("beebop:hash:job:assign",
                       project_hash, redis) == job_ids["assign"]
-
+    # writes initial output file linking project hash with sample hashes
+    with open(fs.output_cluster(project_hash), 'rb') as f:
+        initial_output = pickle.load(f)
+        assert initial_output[0]["hash"] == 'e868c76fec83ee1f69a95bd27b8d5e76'
+        assert initial_output[1]["hash"] == 'f3d9b387e311d5ab59a8c08eb3545dbb'
     # wait for assign job to be finished
     def assign_status_finished():
         job = Job.fetch(job_ids["assign"], connection=redis)
@@ -298,9 +302,9 @@ def test_get_project_returns_404_if_unknown_project_hash(client):
 
 @patch('rq.job.Job.fetch')
 def test_get_project_returns_samples_before_clusters_assigned(mock_fetch):
-    # Fake a project hash that doesn't have clusters yet by adding it to redis
-    # and mocking the rq job, and writing out initial output file without
-    # cluster assignments.
+    # Fake a project hash that doesn't have clusters yet by adding it to redis,
+    # mocking the rq job, and writing out initial output file without cluster
+    # assignments.
     hash = "unit_test_no_clusters_yet"
     redis = Redis()
     redis.hset("beebop:hash:job:assign", hash, "9991")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -303,6 +303,20 @@ def test_get_project_returns_404_if_unknown_project_hash(client):
 
 
 @patch('rq.job.Job.fetch')
+def test_get_project_returns_500_if_status_error(mock_fetch):
+    hash = "unit_test_get_clusters_internal"
+
+    def side_effect(id, connection):
+        raise AttributeError("test")
+    mock_fetch.side_effect = side_effect
+    result = app.get_project(hash)
+    assert result[1] == 500
+    response = read_data(result[0])["error"]
+    assert response["status"] == "failure"
+    assert response["errors"] == [{"error": "Unknown project hash"}]
+
+
+@patch('rq.job.Job.fetch')
 def test_get_project_returns_samples_before_clusters_assigned(mock_fetch):
     # Fake a project hash that doesn't have clusters yet by adding it to redis,
     # mocking the rq job, and writing out initial output file without cluster

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -285,10 +285,11 @@ def test_get_project(client):
 def test_get_project_returns_404_if_unknown_project_hash(client):
     hash = "unit_test_not_known"
     result = app.get_project(hash)
-    assert result.status == "404 Not Found"
-    data = read_data(result)["data"]
+    assert result[0].status == "404 Not Found"
+    response = read_data(result[0])
+    data = response["data"]
     assert data is None
-    errors = read_data(result)["errors"]
+    errors = response["errors"]
     assert errors[0] == {
         "error": "Project hash not found",
         "detail": "Project has does not have an associated job"
@@ -299,7 +300,9 @@ def test_get_project_returns_empty_samples_if_no_cluster_file_yet(client):
     # Fake a project hash that doesn't have clusters yet by adding it to redis
     hash = "unit_test_no_clusters_yet"
     redis = Redis()
-    redis.hset("beebop:hash:job:assign", hash, "9999")
+    redis.hset("beebop:hash:job:assign", hash, "9991")
+    redis.hset("beebop:hash:job:microreact", hash, "9992")
+    redis.hset("beebop:hash:job:network", hash, "9993")
     result = app.get_project(hash)
     assert result.status == "200 OK"
     data = read_data(result)["data"]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -257,6 +257,17 @@ def test_get_project(client):
     assert jsonschema.validate(data, schema, resolver=resolver) is None
 
 
+def test_get_project_returns_empty_samples_if_no_clusters_file(client):
+    hash = "no_clusters"
+    result = app.get_project(hash)
+    assert result.status == "200 OK"
+    data = read_data(result)["data"]
+    assert data["hash"] == hash
+    samples = data["samples"]
+    assert len(samples) == 0
+
+
+
 def test_get_status_internal(client):
     # queue example job
     redis = Redis()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -225,10 +225,10 @@ def test_run_poppunk_internal(qtbot):
     assert read_redis("beebop:hash:job:assign",
                       project_hash, redis) == job_ids["assign"]
     # writes initial output file linking project hash with sample hashes
-    with open(fs.output_cluster(project_hash), 'rb') as f:
-        initial_output = pickle.load(f)
-        assert initial_output[0]["hash"] == 'e868c76fec83ee1f69a95bd27b8d5e76'
-        assert initial_output[1]["hash"] == 'f3d9b387e311d5ab59a8c08eb3545dbb'
+    #with open(fs.output_cluster(project_hash), 'rb') as f:
+    #    initial_output = pickle.load(f)
+    #    assert initial_output[0]["hash"] == 'e868c76fec83ee1f69a95bd27b8d5e76'
+    #    assert initial_output[1]["hash"] == 'f3d9b387e311d5ab59a8c08eb3545dbb'
     # wait for assign job to be finished
     def assign_status_finished():
         job = Job.fetch(job_ids["assign"], connection=redis)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -294,6 +294,7 @@ def test_get_project_returns_404_if_unknown_project_hash(client):
         "detail": "Project hash does not have an associated job"
     }
 
+
 @patch('rq.job.Job.fetch')
 def test_get_project_returns_empty_samples_if_no_cluster_file_yet(mock_fetch):
     # Fake a project hash that doesn't have clusters yet by adding it to redis

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -289,7 +289,10 @@ def test_get_project_returns_404_if_unknown_project_hash(client):
     data = read_data(result)["data"]
     assert data is None
     errors = read_data(result)["errors"]
-    assert errors[0] = {"error": "Project hash not found", "detail": "Project has does not have an associated job"}
+    assert errors[0] = {
+        "error": "Project hash not found",
+        "detail": "Project has does not have an associated job"
+    }
 
 
 def test_get_project_returns_empty_samples_if_no_cluster_file_yet(client):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -225,10 +225,11 @@ def test_run_poppunk_internal(qtbot):
     assert read_redis("beebop:hash:job:assign",
                       project_hash, redis) == job_ids["assign"]
     # writes initial output file linking project hash with sample hashes
-    #with open(fs.output_cluster(project_hash), 'rb') as f:
-    #    initial_output = pickle.load(f)
-    #    assert initial_output[0]["hash"] == 'e868c76fec83ee1f69a95bd27b8d5e76'
-    #    assert initial_output[1]["hash"] == 'f3d9b387e311d5ab59a8c08eb3545dbb'
+    results_fs = PoppunkFileStore(results_storage_location)
+    with open(results_fs.output_cluster(project_hash), 'rb') as f:
+        initial_output = pickle.load(f)
+        assert initial_output[0]["hash"] == 'e868c76fec83ee1f69a95bd27b8d5e76'
+        assert initial_output[1]["hash"] == 'f3d9b387e311d5ab59a8c08eb3545dbb'
     # wait for assign job to be finished
     def assign_status_finished():
         job = Job.fetch(job_ids["assign"], connection=redis)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -285,14 +285,13 @@ def test_get_project(client):
 def test_get_project_returns_404_if_unknown_project_hash(client):
     hash = "unit_test_not_known"
     result = app.get_project(hash)
-    assert result[0].status == "404 Not Found"
-    response = read_data(result[0])
+    assert result[1] == 404
+    response = read_data(result[0])["error"]
     data = response["data"]
-    assert data is None
     errors = response["errors"]
     assert errors[0] == {
         "error": "Project hash not found",
-        "detail": "Project has does not have an associated job"
+        "detail": "Project hash does not have an associated job"
     }
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -289,7 +289,7 @@ def test_get_project_returns_404_if_unknown_project_hash(client):
     data = read_data(result)["data"]
     assert data is None
     errors = read_data(result)["errors"]
-    assert errors[0] = {
+    assert errors[0] == {
         "error": "Project hash not found",
         "detail": "Project has does not have an associated job"
     }

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -257,16 +257,27 @@ def test_get_project(client):
     assert jsonschema.validate(data, schema, resolver=resolver) is None
 
 
-def test_get_project_returns_empty_samples_if_no_clusters_file(client):
-    hash = "no_clusters"
+def test_get_project_returns_404_if_unknown_project_hash(client):
+    hash = "unit_test_not_known"
+    result = app.get_project(hash)
+    assert result.status == "404 Not Found"
+    data = read_data(result)["data"]
+    assert data is None
+    errors = read_data(result)["errors"]
+    assert errors[0] = {"error": "Project hash not found", "detail": "Project has does not have an associated job"}
+
+
+def test_get_project_returns_empty_samples_if_no_cluster_file_yet(client):
+    # Fake a project hash that doesn't have clusters yet by adding it to redis
+    hash = "unit_test_no_clusters_yet"
+    redis = Redis()
+    redis.hset("beebop:hash:job:assign", hash, "9999")
     result = app.get_project(hash)
     assert result.status == "200 OK"
     data = read_data(result)["data"]
     assert data["hash"] == hash
     samples = data["samples"]
     assert len(samples) == 0
-
-
 
 def test_get_status_internal(client):
     # queue example job


### PR DESCRIPTION
When project data is loaded, we read the clusters output file to link the project hash with the sample hashes, as well a reading the cluster assignments. However, this means that we can't load sample hashes and sketches before cluster assignment (though this usually happens pretty quickly) as that file doesn't exist yet.

This branch ensures that an initial output "clusters" file is written immediately, which does not initially include any cluster values but does include the sample hashes for the project. This is overwritten later when the clusters are assigned. This is maybe a bit of a hack, but it seemed preferable to writing out a new type of file..

To test this, run beebop targeting this branch of beebop_py (in the run dependencies script. You'll want to add a reasonable number of fasta files to a project, so that there's a bit of a delay between submitting the job for analysis and the clusters being assigned. It works for me with around 10 files, but note that I've seen the front end processing get stuck with a project using all 17 example fasta files ([ticket to fix this](https://mrc-ide.myjetbrains.com/youtrack/issue/bacpop-134))

Hit the "Start Analysis" button then quickly browse to the Home page, then click on the project name in the list. The project should successfully load with clusters not yet assigned to the samples, but the cluster numbers should be loaded shortly afterwards, and the microreact and network jobs should complete (eventually..)