### PR TITLE
bacpop-142 update references db location

### DIFF
--- a/scripts/download_db
+++ b/scripts/download_db
@@ -48,7 +48,7 @@ if [ -d "$DEST_DIR" ]; then
 fi
 
 echo "Downloading $FILENAME"
-URL=https://sketchdb.blob.core.windows.net/public-dbs/$FILENAME
+URL=https://mrcdata.dide.ic.ac.uk/beebop/$FILENAME
 DBBZ2=$(mktemp).tar.bz2
 wget  --progress=dot:giga $URL -O $DBBZ2
 echo "Unpacking to $DEST"


### PR DESCRIPTION
Get the GPS_v4 db from mrcdata

This won't work with the full db of course, but we don't expect to be using the full v4 db again. 