### PR TITLE
bacpop-145 Make gha PopPUNK installation match dockerfile

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,8 +36,8 @@ jobs:
 
     - name: Install Linux packages
       run: |
-        sudo apt-get update
-        sudo apt-get install ffmpeg libsm6 libxext6  -y
+        sudo apt-get update -q 
+        sudo apt-get install -q -y --no-install-recommends bzip2 ca-certificates git libglib2.0-0 libsm6 libxext6 libxrender1 mercurial openssh-client procps subversion wget
         
     - name: Set up Python 3.10
       uses: actions/setup-python@v2


### PR DESCRIPTION
We've previously had issues because the beebop_py github action was installing PopPUNK in a different way to the dockerfile, so passing beebop_py workflow didn't mean that the container would work.

We're now just installing PopPUNK from conda in the dockerfile - here we do likewise in the gha, and use the same version of Python. 