### PR TITLE
Bacpop-113: add qc to assign clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ curl -sSL https://install.python-poetry.org | python3 -
 To install PopPUNK v2.5, follow these steps:
 
 
-First, create a new conda environment: `conda create --name beebop_py python=3.9` and activate it with `onda activate beebop_pyonda activate beebop_py`
+First, create a new conda environment: `conda create --name beebop_py python=3.9` and activate it with `conda activate beebop_pyonda activate beebop_py`
 
 
 Then install PopPUNK to your computer: 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # beebop_py
 ## Python API for beebop
 
+#### A note on Assign Cluster Quality Control
+The app assigns clusters with quality control (qc) on. This is to enable the `--run-qc` flag as per [here](https://poppunk.bacpop.org/qc.html).
+The arguments along with `--qc-run` can be found at `args.json` in the `qc_dict` json object. The values are [defaults](https://github.com/bacpop/PopPUNK/blob/master/PopPUNK/__main__.py) from PopPunk and are associated with the V8 database.
 ### Usage
 
 #### Clone the repository
@@ -28,7 +31,7 @@ curl -sSL https://install.python-poetry.org | python3 -
 To install PopPUNK v2.5, follow these steps:
 
 
-First, create a new conda environment: `conda create --name beebop_py python=3.9` and activate it with `conda activate beebop_py`
+First, create a new conda environment: `conda create --name beebop_py python=3.9` and activate it with `onda activate beebop_pyonda activate beebop_py`
 
 
 Then install PopPUNK to your computer: 

--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -47,9 +47,6 @@ def get_clusters(hashes_list: list,
     if not os.path.exists(outdir):
         os.mkdir(outdir)
 
-    # create qc_dict
-    qc_dict = {'run_qc': False}
-
     # create dbFuncs
     dbFuncs = setupDBFuncs(args=args.assign)
 
@@ -66,7 +63,7 @@ def get_clusters(hashes_list: list,
 
     # run query assignment
     wrapper = PoppunkWrapper(fs, db_paths, args, p_hash)
-    wrapper.assign_clusters(dbFuncs, qc_dict, qNames)
+    wrapper.assign_clusters(dbFuncs, qNames)
 
     queries_names, queries_clusters, _, _, _, _, _ = \
         summarise_clusters(outdir, args.assign.species, db_paths.db, qNames)

--- a/beebop/poppunkWrapper.py
+++ b/beebop/poppunkWrapper.py
@@ -24,7 +24,6 @@ class PoppunkWrapper:
 
     def assign_clusters(self,
                         dbFuncs: DatabaseFileStore,
-                        qc_dict: dict,
                         qNames: list) -> None:
         """
         :param dbFuncs: [database functions, generated with poppunks
@@ -37,7 +36,7 @@ class PoppunkWrapper:
             ref_db=self.db_paths.db,
             qNames=qNames,
             output=self.fs.output(self.p_hash),
-            qc_dict=qc_dict,
+            qc_dict=vars(self.args.assign.qc_dict),
             update_db=self.args.assign.update_db,
             write_references=self.args.assign.write_references,
             distances=self.db_paths.distances,

--- a/beebop/poppunkWrapper.py
+++ b/beebop/poppunkWrapper.py
@@ -28,7 +28,6 @@ class PoppunkWrapper:
         """
         :param dbFuncs: [database functions, generated with poppunks
             setupDBFuncs()]
-        :param qc_dict: [dict whether qc should run or not]
         :param qNames: [hd5 database with all sketches]
         """
         assign_query_hdf5(

--- a/beebop/resources/args.json
+++ b/beebop/resources/args.json
@@ -17,7 +17,19 @@
         "min_kmer_count": 0,
         "exact_count": false,
         "species": "Streptococcus pneumoniae",
-        "serial": false
+        "serial": false,
+        "qc_dict": {
+            "run_qc": true,
+            "type_isolate": null,
+            "max_a_dist": 0.5,
+            "max_pi_dist": 0.1,
+            "prop_zero": 0.05,
+            "prop_n": 0.1,
+            "max_merge": -1,
+            "betweenness": true,
+            "retain_failures": false,
+            "no_remove": false
+        }
     },
     "visualise":{
         "threads":1,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -674,6 +674,7 @@ def test_add_query_ref_status():
     assert get_node_status(22) == 'query'
     assert get_node_status(20) == 'ref'
 
+
 @patch('beebop.poppunkWrapper.assign_query_hdf5')
 def test_poppunk_wrapper_assign_cluster(mock_assign):
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -20,6 +20,7 @@ from tests import setup
 import xml.etree.ElementTree as ET
 import pickle
 import shutil
+import PopPUNK.assign
 
 from beebop import __version__ as beebop_version
 from beebop import app
@@ -27,6 +28,7 @@ from beebop import versions
 from beebop import assignClusters
 from beebop import visualise
 from beebop import utils
+from beebop.poppunkWrapper import PoppunkWrapper
 
 import beebop.schemas
 from beebop.filestore import PoppunkFileStore, FileStore, DatabaseFileStore
@@ -671,3 +673,36 @@ def test_add_query_ref_status():
     assert get_node_status(21) == 'query'
     assert get_node_status(22) == 'query'
     assert get_node_status(20) == 'ref'
+
+@patch('beebop.poppunkWrapper.assign_query_hdf5')
+def test_poppunk_wrapper_assign_cluster(mock_assign):
+
+    db_paths = DatabaseFileStore('./storage/GPS_v8_ref')
+    wrapper = PoppunkWrapper(fs, db_paths, args, "random hash")
+
+    wrapper.assign_clusters(db_paths, ["ms1", "ms2"])
+
+    mock_assign.assert_called_with(
+        dbFuncs=db_paths,
+        ref_db=db_paths.db,
+        qNames=["ms1", "ms2"],
+        output=fs.output(wrapper.p_hash),
+        qc_dict=vars(args.assign.qc_dict),
+        update_db=args.assign.update_db,
+        write_references=args.assign.write_references,
+        distances=db_paths.distances,
+        serial=args.assign.serial,
+        threads=args.assign.threads,
+        overwrite=args.assign.overwrite,
+        plot_fit=args.assign.plot_fit,
+        graph_weights=args.assign.graph_weights,
+        model_dir=db_paths.db,
+        strand_preserved=args.assign.strand_preserved,
+        previous_clustering=db_paths.db,
+        external_clustering=fs.external_clustering,
+        core=args.assign.core_only,
+        accessory=args.assign.accessory_only,
+        gpu_dist=args.assign.gpu_dist,
+        gpu_graph=args.assign.gpu_graph,
+        save_partial_query_graph=args.assign.save_partial_query_graph
+    )


### PR DESCRIPTION
This adds quality control (qc) to true with default values. Thus assign cluster now goes through quality control. 

Note: this will need merging with Beebop itself