### PR TITLE
Bug: Create new output folder when running poppunk

### DIFF
--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -125,6 +125,7 @@ def setup_output_directory(fs: PoppunkFileStore, p_hash: str) -> str:
     os.makedirs(outdir)
     return outdir
 
+
 def create_sketches_dict(hashes_list: list, fs: PoppunkFileStore) -> dict:
     """
     [Create a dictionary of sketches for all query samples]

--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -112,17 +112,18 @@ def get_clusters(
 
 def setup_output_directory(fs: PoppunkFileStore, p_hash: str) -> str:
     """
-    [Create output directory that stores all files from PopPUNK assign job]
+    [Create output directory that stores all files from PopPUNK assign job.
+    If the directory already exists, it is removed and recreated]
 
     :param fs: [PoppunkFileStore with paths to input files]
     :param p_hash: [project hash]
     :return str: [path to output directory]
     """
     outdir = fs.output(p_hash)
-    if not os.path.exists(outdir):
-        os.mkdir(outdir)
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    os.makedirs(outdir)
     return outdir
-
 
 def create_sketches_dict(hashes_list: list, fs: PoppunkFileStore) -> dict:
     """

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1004,6 +1004,24 @@ def test_setup_output_directory():
 
     assert outdir == fs.output(hash)
 
+@patch("os.makedirs")
+@patch("os.path.exists")
+@patch("shutil.rmtree")
+def test_setup_output_directory_removes_existing_directory(mock_rmtree, mock_exists, mock_makedirs):
+    # Test when the directory already exists
+    mock_exists.return_value = True
+    mock_filestore = Mock()
+    mock_directory = "/mock/output/directory"
+    mock_filestore.output.return_value = mock_directory
+
+    result = assignClusters.setup_output_directory(mock_filestore, "mock_hash")
+
+    mock_filestore.output.assert_called_once_with("mock_hash")
+    mock_exists.assert_called_once_with(mock_directory)
+    mock_rmtree.assert_called_once_with(mock_directory)
+    mock_makedirs.assert_called_once_with(mock_directory)
+    assert result == mock_directory
+
 
 def test_create_sketches_dict():
     sketches = {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1004,10 +1004,13 @@ def test_setup_output_directory():
 
     assert outdir == fs.output(hash)
 
+
 @patch("os.makedirs")
 @patch("os.path.exists")
 @patch("shutil.rmtree")
-def test_setup_output_directory_removes_existing_directory(mock_rmtree, mock_exists, mock_makedirs):
+def test_setup_output_directory_removes_existing_directory(
+    mock_rmtree, mock_exists, mock_makedirs
+):
     # Test when the directory already exists
     mock_exists.return_value = True
     mock_filestore = Mock()


### PR DESCRIPTION
As development occurs, Poppunk will change the output files it produces... Thus currently there is _dead_ files that POPpunk no longer outputs. These cause issues and become stale....

Thus, if an output folder exists; we blitz the folder and create a new one on running poppunk (assign step)