### PR TITLE
Script: Add convert .gt file format to .csv.gz + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ To use GPU, ensure the following conditions are met:
 - The host machine has a GPU and the NVIDIA drivers and cuda-toolkit are installed with correct versions. [Check the NVIDIA documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-linux)
 - The necessary libraries for GPU support are installed in your environment.[RAPIDS](https://rapids.ai/),[numba](https://numba.readthedocs.io/en/stable/user/installing.html), [cupy](https://docs.cupy.dev/en/stable/install.html)
 - Ensure any new PopPUNK databases have *graph.csv.gz* file. If not run script in scripts folder: `python gt-to-csv-gz.py` with
-
   - `--input` the path to the graph .gt file
-  - `--output` the path to the output csv.gz file. This should be the same path as the graph file, but with the .csv.gz extension.
+
 **Note:** If you installed **pp-sketchlib, PopPUNK, and mandrake** before installing CUDA, you will need to reinstall them to ensure CUDA-enabled versions are installed.

--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ To use GPU, ensure the following conditions are met:
   - `--input` the path to the graph .gt file
   - `--output` the path to the output csv.gz file
 - In `args.json` set the `gpu_graph` and `gpu_dist` to `True` for both `assign` and `visualise` fields.
+*Note: may need to reinstall and **pp-sketchlib, PopPUNK and mandrake** to ensure CUDA enabled versions are installed*

--- a/README.md
+++ b/README.md
@@ -127,3 +127,14 @@ You can build the image with `/docker/build --with-dev`, this new image can now 
 A pull request can be created so GHA pushes the images to the docker hub. Add `--with-dev` to the build & push commands `pipeline.yaml`.
 **Ensure to remove the `--with-dev` flag before merging the PR.**
 Then on the `beebop-deploy` the api image can be updated with the new dev image.
+
+### GPU
+
+To use GPU, ensure the following conditions are met:
+
+- The host machine has a GPU and the NVIDIA drivers and cuda-toolkit are installed with correct versions. [Check the NVIDIA documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-linux)
+- The necessary libraries for GPU support are installed in your environment.[Check RAPIDS documentation](https://rapids.ai/)
+- Ensure any new databases have *graph.csv.gz* file. If not run script in scripts folder: `python gt-to-csv-gz.py` with
+  - `--input` the path to the graph .gt file
+  - `--output` the path to the output csv.gz file
+- In `args.json` set the `gpu_graph` and `gpu_dist` to `True` for both `assign` and `visualise` fields.

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ Then on the `beebop-deploy` the api image can be updated with the new dev image.
 To use GPU, ensure the following conditions are met:
 
 - The host machine has a GPU and the NVIDIA drivers and cuda-toolkit are installed with correct versions. [Check the NVIDIA documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-linux)
-- The necessary libraries for GPU support are installed in your environment.[Check RAPIDS documentation](https://rapids.ai/)
-- Ensure any new databases have *graph.csv.gz* file. If not run script in scripts folder: `python gt-to-csv-gz.py` with
+- The necessary libraries for GPU support are installed in your environment.[RAPIDS](https://rapids.ai/),[numba](https://numba.readthedocs.io/en/stable/user/installing.html), [cupy](https://docs.cupy.dev/en/stable/install.html)
+- Ensure any new PopPUNK databases have *graph.csv.gz* file. If not run script in scripts folder: `python gt-to-csv-gz.py` with
+
   - `--input` the path to the graph .gt file
-  - `--output` the path to the output csv.gz file
-- In `args.json` set the `gpu_graph` and `gpu_dist` to `True` for both `assign` and `visualise` fields.
-*Note: may need to reinstall and **pp-sketchlib, PopPUNK and mandrake** to ensure CUDA enabled versions are installed*
+  - `--output` the path to the output csv.gz file. This should be the same path as the graph file, but with the .csv.gz extension.
+**Note:** If you installed **pp-sketchlib, PopPUNK, and mandrake** before installing CUDA, you will need to reinstall them to ensure CUDA-enabled versions are installed.

--- a/scripts/gt-to-csv-gz.py
+++ b/scripts/gt-to-csv-gz.py
@@ -38,8 +38,7 @@ def get_input_output_paths():
         raise FileNotFoundError(f"Input file {args.input} does not exist.")
     if not args.input.endswith(".gt"):
         raise ValueError("Input file must be a .gt file.")
-    
-    
+
     return args.input, args.input.replace(".gt", ".csv.gz")
 
 

--- a/scripts/gt-to-csv-gz.py
+++ b/scripts/gt-to-csv-gz.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import graph_tool.all as gt
+import argparse
+
+# This script converts a graph-tool graph to a gzipped CSV file.
+# PopPUNK's GPU accelerated graphing library cuGraph cannot read .gt files, 
+# so we need to convert it to csv that cuGraph can read.
+
+
+def save_gt_graph_as_csv_gzip(graph: gt.Graph, gzip_output_filepath: str):
+    edges = [(e.source(), e.target()) for e in graph.edges()]
+    # Add vertices with no edges as source and destination as themselves
+    no_edge_vertices = [
+        (v, v)
+        for v in graph.get_vertices()
+        if len(graph.get_all_edges(v)) == 0
+    ]
+    edges.extend(no_edge_vertices)
+    df_edges = pd.DataFrame(edges, columns=["source", "destination"])
+    df_edges.to_csv(gzip_output_filepath, index=False, compression="gzip")
+
+
+def get_input_output_paths():
+    parser = argparse.ArgumentParser(
+        description="Convert a graph-tool graph to a gzipped CSV file."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=True,
+        help="Path to the input graph-tool .gt file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=True,
+        help="Path to the output gzipped CSV file.",
+    )
+    args = parser.parse_args()
+
+    return args.input, args.output
+
+
+def main():
+    input_path, output_path = get_input_output_paths()
+    g = gt.load_graph(input_path, fmt="gt")
+    save_gt_graph_as_csv_gzip(g, output_path)
+    print(f"Graph saved as gzipped CSV at {output_path}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gt-to-csv-gz.py
+++ b/scripts/gt-to-csv-gz.py
@@ -3,7 +3,7 @@ import graph_tool.all as gt
 import argparse
 
 # This script converts a graph-tool graph to a gzipped CSV file.
-# PopPUNK's GPU accelerated graphing library cuGraph cannot read .gt files, 
+# PopPUNK's GPU accelerated graphing library cuGraph cannot read .gt files,
 # so we need to convert it to csv that cuGraph can read.
 
 

--- a/scripts/gt-to-csv-gz.py
+++ b/scripts/gt-to-csv-gz.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import graph_tool.all as gt
 import argparse
+import os
 
 # This script converts a graph-tool graph to a gzipped CSV file.
 # PopPUNK's GPU accelerated graphing library cuGraph cannot read .gt files,
@@ -31,16 +32,15 @@ def get_input_output_paths():
         required=True,
         help="Path to the input graph-tool .gt file.",
     )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        required=True,
-        help="Path to the output gzipped CSV file.",
-    )
     args = parser.parse_args()
 
-    return args.input, args.output
+    if not os.path.exists(args.input):
+        raise FileNotFoundError(f"Input file {args.input} does not exist.")
+    if not args.input.endswith(".gt"):
+        raise ValueError("Input file must be a .gt file.")
+    
+    
+    return args.input, args.input.replace(".gt", ".csv.gz")
 
 
 def main():


### PR DESCRIPTION
This PR adds script that converts .gt(graph-tool) file to a .csv.gz file. This is needed as GPU graphing library cugraph cannot read .gt file format, thus we need to convert. 

This has already been done for all databases and is already in mrcdata/beebop.

There is also some docs updates to run beebop with a gpu

Testing:
run python script and check the .csv.gz file shows up Eg: `python gt-to-csv-gz.py -i /home/$USER/code/beebop_py/storage/dbs/gas_database/gas_database_graph.gt -o /home/$USER/code/beebop_py/storage/dbs/gas_database/gas_database_graph.csv.gz`