### PR TITLE
Mrc-216 Add error message for novel strain failiure

### DIFF
--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -309,7 +309,7 @@ def handle_files_manipulation(
 
 def update_external_clusters(
     config: ClusteringConfig,
-    query_names: list,
+    found_in_full_db_query_names: list,
     external_clusters: dict,
     previous_query_clustering: str,
 ) -> None:
@@ -326,7 +326,7 @@ def update_external_clusters(
 
     :param config: [ClusteringConfig
         with all necessary information]
-    :param query_names: [list of sample hashes
+    :param found_in_full_db_query_names: [list of sample hashes
         that were not found in the initial external clusters file]
     :param external_clusters: [dict of sample hashes
         to external cluster labels]
@@ -340,13 +340,13 @@ def update_external_clusters(
     update_external_clusters_csv(
         previous_query_clustering,
         not_found_prev_querying,
-        query_names,
+        found_in_full_db_query_names,
     )
 
     external_clusters_full_db, not_found_query_names_full_db = (
         get_external_clusters_from_file(
             not_found_prev_querying,
-            query_names,
+            found_in_full_db_query_names,
             config.external_clusters_prefix,
         )
     )

--- a/beebop/assignClusters.py
+++ b/beebop/assignClusters.py
@@ -193,7 +193,7 @@ def handle_external_clusters(
             )
         )
         output_full_tmp = config.fs.output_tmp(config.p_hash)
-        not_found_query_names_new, not_found_query_clusters_new = (
+        found_query_names_full_db, found_query_clusters_full_db = (
             handle_not_found_queries(
                 config,
                 sketches_dict,
@@ -202,8 +202,8 @@ def handle_external_clusters(
                 not_found_query_clusters,
             )
         )
-        queries_names.extend(not_found_query_names_new)
-        queries_clusters.extend(not_found_query_clusters_new)
+        queries_names.extend(found_query_names_full_db)
+        queries_clusters.extend(found_query_clusters_full_db)
         update_external_clusters(
             config,
             not_found_query_names,
@@ -309,7 +309,7 @@ def handle_files_manipulation(
 
 def update_external_clusters(
     config: ClusteringConfig,
-    not_found_query_names: list,
+    query_names: list,
     external_clusters: dict,
     previous_query_clustering: str,
 ) -> None:
@@ -326,8 +326,8 @@ def update_external_clusters(
 
     :param config: [ClusteringConfig
         with all necessary information]
-    :param not_found_query_names: [list of sample hashes
-        that were not found]
+    :param query_names: [list of sample hashes
+        that were not found in the initial external clusters file]
     :param external_clusters: [dict of sample hashes
         to external cluster labels]
     :param previous_query_clustering: [path to previous
@@ -340,15 +340,47 @@ def update_external_clusters(
     update_external_clusters_csv(
         previous_query_clustering,
         not_found_prev_querying,
-        not_found_query_names,
+        query_names,
     )
 
-    external_clusters_not_found, _ = get_external_clusters_from_file(
-        not_found_prev_querying,
-        not_found_query_names,
-        config.external_clusters_prefix,
+    external_clusters_full_db, not_found_query_names_full_db = (
+        get_external_clusters_from_file(
+            not_found_prev_querying,
+            query_names,
+            config.external_clusters_prefix,
+        )
     )
-    external_clusters.update(external_clusters_not_found)
+
+    process_unassignable_samples(
+        not_found_query_names_full_db, config.fs, config.p_hash
+    )
+
+    external_clusters.update(external_clusters_full_db)
+
+
+def process_unassignable_samples(
+    unassignable_names: list[str], fs: PoppunkFileStore, p_hash: str
+) -> None:
+    """
+    [Process samples that are unassignable to external clusters.
+    These samples are added to the QC error report file.]
+
+    :param unassignable_names: [List of sample hashes that
+    are unassignable to external clusters.]
+    :param fs: [PoppunkFileStore with paths to input/output files.]
+    :param p_hash: [Project hash.]
+    """
+    if not unassignable_names:
+        return
+
+    qc_report_path = fs.output_qc_report(p_hash)
+    strain_assignment_error = (
+        "Unable to assign to an existing strain - potentially novel genotype"
+    )
+
+    with open(qc_report_path, "a") as report_file:
+        for sample_hash in unassignable_names:
+            report_file.write(f"{sample_hash}\t{strain_assignment_error}\n")
 
 
 def merge_txt_files(main_file: str, merge_file: str) -> None:
@@ -442,7 +474,7 @@ def delete_include_files(
 
 
 def assign_clusters_to_result(
-    query_cluster_mapping: Union[dict.items, zip]
+    query_cluster_mapping: Union[dict.items, zip],
 ) -> dict:
     """
     [Assign clusters to the result dictionary,
@@ -501,8 +533,12 @@ def save_external_to_poppunk_clusters(
     """
     external_to_poppunk_clusters = {}
     for i, name in enumerate(queries_names):
-        external_to_poppunk_clusters[external_clusters[name]["cluster"]] = str(
+        external_cluster = external_clusters.get(name, {}).get("cluster")
+        if external_cluster is None:
+            continue
+        external_to_poppunk_clusters[external_cluster] = str(
             queries_clusters[i]
         )
+
     with open(fs.external_to_poppunk_clusters(p_hash), "wb") as f:
         pickle.dump(external_to_poppunk_clusters, f)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1251,7 +1251,10 @@ def test_update_external_clusters(
     external_clusters = {"sample1": "GPSC69", "sample2": "GPSC420"}
     new_external_clusters = {"sample3": "GPSC11", "samples4": "GPSC33"}
     not_found_samples = ["sample4"]
-    mock_get_external_clusters.return_value = (new_external_clusters, not_found_samples)
+    mock_get_external_clusters.return_value = (
+        new_external_clusters,
+        not_found_samples,
+    )
 
     assignClusters.update_external_clusters(
         config, query_names, external_clusters, previous_query_clustering
@@ -1812,6 +1815,7 @@ def test_get_network_files_for_zip(mock_component_filepath):
         f"visualise_{cluster_num}_cytoscape.csv",
     ]
 
+
 def test_process_unassignable_samples(tmp_path):
     unassignable_samples = ["sample1", "sample2"]
     strain_assignment_error = (
@@ -1825,16 +1829,17 @@ def test_process_unassignable_samples(tmp_path):
     report_path = tmp_path / "qc_report.txt"
 
     fs.output_qc_report.return_value = str(report_path)
-    
+
     assignClusters.process_unassignable_samples(
         unassignable_samples, fs, "hash"
     )
-    
+
     fs.output_qc_report.assert_called_once_with("hash")
-    
+
     qc_report_lines = list(report_path.read_text().splitlines())
     assert qc_report_lines == expected_output
-    
+
+
 def test_process_unassignable_samples_no_samples():
     fs = Mock()
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -216,7 +216,8 @@ def test_visualise_per_cluster(mock_create_subgraph, mock_replace_filehashes):
         fs.output_visualisations(p_hash, 16), setup.name_mapping
     )
     mock_create_subgraph.assert_called_with(
-        fs.output_visualisations(p_hash, 16), setup.name_mapping, "16")
+        fs.output_visualisations(p_hash, 16), setup.name_mapping, "16"
+    )
 
 
 @patch("beebop.visualise.replace_filehashes")
@@ -1233,31 +1234,39 @@ def test_handle_files_manipulation(mock_delete, mock_copy, mock_merge, config):
     )
 
 
+@patch("beebop.assignClusters.process_unassignable_samples")
 @patch("beebop.assignClusters.update_external_clusters_csv")
 @patch("beebop.assignClusters.get_external_clusters_from_file")
 def test_update_external_clusters(
-    mock_get_external_clusters, mock_update_external_clusters, config
+    mock_get_external_clusters,
+    mock_update_external_clusters,
+    mock_process_unassignable_samples,
+    config,
 ):
     previous_query_clustering = "previous_query_clustering"
     config.fs.external_previous_query_clustering_tmp.return_value = (
         "tmp_previous_query_clustering"
     )
-    not_found = ["sample3", "samples4"]
+    query_names = ["sample3", "samples4"]
     external_clusters = {"sample1": "GPSC69", "sample2": "GPSC420"}
     new_external_clusters = {"sample3": "GPSC11", "samples4": "GPSC33"}
-    mock_get_external_clusters.return_value = (new_external_clusters, [])
+    not_found_samples = ["sample4"]
+    mock_get_external_clusters.return_value = (new_external_clusters, not_found_samples)
 
     assignClusters.update_external_clusters(
-        config, not_found, external_clusters, previous_query_clustering
+        config, query_names, external_clusters, previous_query_clustering
     )
 
     mock_get_external_clusters.assert_called_once_with(
         "tmp_previous_query_clustering",
-        not_found,
+        query_names,
         config.external_clusters_prefix,
     )
     mock_update_external_clusters.assert_called_once_with(
-        previous_query_clustering, "tmp_previous_query_clustering", not_found
+        previous_query_clustering, "tmp_previous_query_clustering", query_names
+    )
+    mock_process_unassignable_samples.assert_called_once_with(
+        not_found_samples, config.fs, config.p_hash
     )
 
     assert external_clusters == {
@@ -1529,9 +1538,7 @@ def test_create_subgraph(
 
     utils.create_subgraph("network_folder", filename_dict, "1")
 
-    mock_get_component_filepath.assert_called_once_with(
-        "network_folder", "1"
-    )
+    mock_get_component_filepath.assert_called_once_with("network_folder", "1")
     mock_build_subgraph.assert_called_once_with(
         "network_component_1.graphml", query_names
     )
@@ -1804,3 +1811,33 @@ def test_get_network_files_for_zip(mock_component_filepath):
         f"pruned_{component_filename}",
         f"visualise_{cluster_num}_cytoscape.csv",
     ]
+
+def test_process_unassignable_samples(tmp_path):
+    unassignable_samples = ["sample1", "sample2"]
+    strain_assignment_error = (
+        "Unable to assign to an existing strain - potentially novel genotype"
+    )
+    expected_output = [
+        f"{sample}\t{strain_assignment_error}"
+        for sample in unassignable_samples
+    ]
+    fs = Mock()
+    report_path = tmp_path / "qc_report.txt"
+
+    fs.output_qc_report.return_value = str(report_path)
+    
+    assignClusters.process_unassignable_samples(
+        unassignable_samples, fs, "hash"
+    )
+    
+    fs.output_qc_report.assert_called_once_with("hash")
+    
+    qc_report_lines = list(report_path.read_text().splitlines())
+    assert qc_report_lines == expected_output
+    
+def test_process_unassignable_samples_no_samples():
+    fs = Mock()
+
+    assignClusters.process_unassignable_samples([], fs, "")
+
+    fs.output_qc_report.assert_not_called()


### PR DESCRIPTION
Summary:
This PR introduces an error message when a cluster cannot be assigned to a sample. Specifically, if a sample cannot be assigned to a reference cluster or full database, it is considered to have a "novel" strain. A descriptive message (provided by Nick) is added to the QC report, which already includes failed samples.

UI Update:
The message appears as a tooltip when hovering over the failed sample in the UI.

Testing Instructions:
1. Run both beebop and beebop_py using this branch.
2. Upload the sample I've sent via message and run the analysis.
3. Verify that the tooltip on the failed sample shows the correct message (as shown in the screenshot).

![image](https://github.com/user-attachments/assets/a651013a-2455-4ef2-bd6f-a6f93427fa29)
