### PR TITLE
Bacpop-218 Cleanup Flask return + types 

### DIFF
--- a/.github/workflows/pycodestyle_workflow.yml
+++ b/.github/workflows/pycodestyle_workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -690,7 +690,8 @@ def generate_microreact_url_internal(
             return jsonify(response_success({"cluster": cluster, "url": url}))
         case 500:
             raise InternalServerError(
-                "Microreact reported Internal Server Error. Most likely Token is invalid!"
+                "Microreact reported Internal Server Error. "
+                "Most likely Token is invalid!"
             )
         case 404:
             raise NotFound("Cannot reach Microreact API")

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -440,8 +440,8 @@ def setup_db_file_stores(
     return ref_db_fs, full_db_fs
 
 
-@app.route("/status/<p_hash>")
-def get_status(p_hash) -> Response:
+@app.route("/status/<string:p_hash>")
+def get_status(p_hash: str) -> Response:
     """
     [returns job statuses for all jobs with given project hash. Possible
     values are: queued, started, deferred, finished, stopped, canceled,
@@ -508,9 +508,9 @@ def get_status_internal(
         raise NotFound("Unknown project hash")
 
 
-@app.route("/results/networkGraphs/<p_hash>", methods=["GET"])
+@app.route("/results/networkGraphs/<string:p_hash>", methods=["GET"])
 def get_network_graphs(
-    p_hash,
+    p_hash: str,
 ) -> Response:
     """
     [returns all network pruned graphml files for a given project hash]
@@ -541,8 +541,8 @@ def get_network_graphs(
 
 
 # get job result
-@app.route("/results/<result_type>", methods=["POST"])
-def get_results(result_type) -> Response:
+@app.route("/results/<string:result_type>", methods=["POST"])
+def get_results(result_type: str) -> Response:
     """
     [Route to get results for the specified type of analysis.
     Request object includes:
@@ -726,8 +726,8 @@ def update_microreact_json(json_microreact: dict, cluster_num: str) -> None:
     json_microreact["tables"]["table-1"]["columns"] += default_cols_to_add
 
 
-@app.route("/project/<p_hash>", methods=["GET"])
-def get_project(p_hash) -> Response:
+@app.route("/project/<string:p_hash>", methods=["GET"])
+def get_project(p_hash: str) -> Response:
     """
     [Loads all project data for a given project hash so the project can be
     re-opened in beebop.]

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -50,7 +50,8 @@ def response_success(data: Any) -> ResponseBody:
 def response_failure(error: ResponseError) -> ResponseBody:
     """
     :param error: [error object with error message and details]
-    :return Response: [response object for error response holding error message]
+    :return Response: [response object for error
+    response holding error message]
     """
     response = ResponseBody(status="failure", errors=[error], data=[])
     return response

--- a/beebop/app.py
+++ b/beebop/app.py
@@ -311,7 +311,7 @@ def run_poppunk_internal(
     :param q: [redis queue]
     :param species: [type of species to be analyzed]
     :param amr_metadata: [AMR metadata for query samples]
-    :return json: [response object with all job IDs stored in 'data']
+    :return Response: [response object with all job IDs stored in 'data']
     """
     fs = PoppunkFileStore(storage_location)
     species_args = getattr(args.species, species, None)
@@ -516,7 +516,7 @@ def get_network_graphs(
     [returns all network pruned graphml files for a given project hash]
 
     :param p_hash: [project hash]
-    :return json: [response object with all graphml files stored in 'data']
+    :return Response: [response object with all graphml files stored in 'data']
     """
     fs = PoppunkFileStore(storage_location)
     try:
@@ -616,7 +616,7 @@ def get_clusters_json(p_hash: str, storage_location: str) -> Response:
 
     :param p_hash: [project hash]
     :param storage_location: [storage location]
-    :return json: [response object with cluster results stored in 'data']
+    :return Response: [response object with cluster results stored in 'data']
     """
     cluster_result = get_cluster_assignments(p_hash, storage_location)
     cluster_dict = {value["hash"]: value for value in cluster_result.values()}
@@ -663,7 +663,7 @@ def generate_microreact_url_internal(
     :param api_token: [this ust be provided by the user. The new API does
         not allow generating a URL without a token.]
     :param storage_location: [storage location]
-    :return json: [response object with URL stored in 'data']
+    :return Response: [response object with URL stored in 'data']
     """
     fs = PoppunkFileStore(storage_location)
 

--- a/beebop/config.py
+++ b/beebop/config.py
@@ -1,0 +1,45 @@
+import os
+from types import SimpleNamespace
+import json
+
+
+class ConfigurationError(Exception):
+    """Raised when required configuration is missing or invalid."""
+
+    pass
+
+
+def get_environment() -> tuple[str, str, str]:
+    """
+    Get the environment variables required for the application.
+
+    :return: A tuple containing the storage location, database location,
+             and Redis host.
+    """
+    storage_location = os.getenv("STORAGE_LOCATION")
+    dbs_location = os.getenv("DBS_LOCATION")
+    redis_host = os.getenv("REDIS_HOST")
+    if not storage_location:
+        raise ConfigurationError(
+            "STORAGE_LOCATION environment variable is not set."
+        )
+    if not dbs_location:
+        raise ConfigurationError(
+            "DBS_LOCATION environment variable is not set."
+        )
+    if not redis_host:
+        redis_host = "127.0.0.1"
+    return storage_location, dbs_location, redis_host
+
+
+def get_args() -> SimpleNamespace:
+    """
+    [Read in fixed arguments to poppunk that are always set, or used as
+    defaults. This is needed because of the large number of arguments that
+    poppunk needs]
+
+    :return dict: [arguments loaded from json]
+    """
+    with open("./beebop/resources/args.json") as a:
+        args_json = a.read()
+    return json.loads(args_json, object_hook=lambda d: SimpleNamespace(**d))

--- a/beebop/dataClasses.py
+++ b/beebop/dataClasses.py
@@ -46,11 +46,11 @@ class SpeciesConfig:
 @dataclass
 class ResponseError:
     error: str
-    details: Optional[str] = None
+    detail: Optional[str] = None
 
 
 @dataclass
-class Response:
+class ResponseBody:
     status: str
     errors: list[ResponseError]
     data: Any

--- a/beebop/dataClasses.py
+++ b/beebop/dataClasses.py
@@ -41,3 +41,16 @@ class SpeciesConfig:
     external_clusters_file: str
     db_metadata_file: str
     qc_dict: Qc
+
+
+@dataclass
+class ResponseError:
+    error: str
+    details: Optional[str] = None
+
+
+@dataclass
+class Response:
+    status: str
+    errors: list[ResponseError]
+    data: Any

--- a/beebop/utils.py
+++ b/beebop/utils.py
@@ -267,8 +267,7 @@ def get_external_clusters_from_file(
     valid_clusters = filtered_df[found_mask]
     hash_cluster_info = {
         sample: {
-            "cluster":
-                f"{external_clusters_prefix}{get_lowest_cluster(cluster)}",
+            "cluster": f"{external_clusters_prefix}{get_lowest_cluster(cluster)}",
             "raw_cluster_num": cluster,
         }
         for sample, cluster in zip(

--- a/beebop/utils.py
+++ b/beebop/utils.py
@@ -267,7 +267,8 @@ def get_external_clusters_from_file(
     valid_clusters = filtered_df[found_mask]
     hash_cluster_info = {
         sample: {
-            "cluster": f"{external_clusters_prefix}{get_lowest_cluster(cluster)}",
+            "cluster":
+                f"{external_clusters_prefix}{get_lowest_cluster(cluster)}",
             "raw_cluster_num": cluster,
         }
         for sample, cluster in zip(

--- a/beebop/utils.py
+++ b/beebop/utils.py
@@ -10,19 +10,6 @@ from pathlib import PurePath
 import graph_tool.all as gt
 
 
-def get_args() -> SimpleNamespace:
-    """
-    [Read in fixed arguments to poppunk that are always set, or used as
-    defaults. This is needed because of the large number of arguments that
-    poppunk needs]
-
-    :return dict: [arguments loaded from json]
-    """
-    with open("./beebop/resources/args.json") as a:
-        args_json = a.read()
-    return json.loads(args_json, object_hook=lambda d: SimpleNamespace(**d))
-
-
 def get_cluster_num(cluster: str) -> str:
     """
     [Extract the numeric part from a cluster label, regardless of the prefix.]

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,7 +207,6 @@ files = [
 [package.dependencies]
 blinker = ">=1.6.2"
 click = ">=8.1.3"
-importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.1.2"
 Jinja2 = ">=3.1.2"
 Werkzeug = ">=2.3.7"
@@ -269,25 +268,6 @@ files = [
 
 [package.dependencies]
 numpy = ">=1.17.3"
-
-[[package]]
-name = "importlib-metadata"
-version = "7.0.1"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
-    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
-]
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "iniconfig"
@@ -979,22 +959,7 @@ files = [
     {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
 ]
 
-[[package]]
-name = "zipp"
-version = "3.17.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
-    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.11"
-content-hash = "2cb84f3cf2fc54d26dc36bb8f8e666ddfa6019aca58a2e11bf8b128ac1cac553"
+python-versions = ">=3.10,<3.11"
+content-hash = "64dfc13f950e3453e7145f3b9d20c796b42e97640430bc69e27e51c92f7cc560"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["muppi1993 <clara.gronemeyer20@imperial.ac.uk>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.11"
+python = ">=3.10,<3.11"
 Flask = "^2.0"
 jsonschema = "^4.4"
 pycodestyle = "^2.8.0"

--- a/tests/generate_visualisation_input.py
+++ b/tests/generate_visualisation_input.py
@@ -5,7 +5,7 @@ from PopPUNK.assign import assign_query_hdf5
 from PopPUNK.web import summarise_clusters, sketch_to_hdf5
 from PopPUNK.utils import setupDBFuncs
 from beebop.filestore import PoppunkFileStore, DatabaseFileStore
-from beebop.utils import get_args
+from beebop.config import get_args
 from tests import setup
 
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -5,7 +5,7 @@ from beebop import visualise
 from tests import hdf5_to_json
 import json
 from beebop.filestore import PoppunkFileStore, FileStore, DatabaseFileStore
-from beebop.utils import get_args
+from beebop.config import get_args
 import pandas as pd
 
 schemas = beebop.schemas.Schema()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,7 +104,12 @@ def test_results_microreact(client):
     )
     error = json.loads(error_response.data)["error"]
     assert error["status"] == "failure"
-    assert error["errors"][0]["error"] == "Wrong Token"
+    assert error["errors"][0]["error"] == "Internal Server Error"
+    assert (
+        error["errors"][0]["detail"]
+        == "Microreact reported Internal Server Error. "
+        "Most likely Token is invalid!"
+    )
 
 
 def test_network_results_zip(client):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -72,7 +72,7 @@ def test_project_not_found(client):
     response = json.loads(response.data)["error"]
     assert response["status"] == "failure"
     err = response["errors"][0]
-    assert err["error"] == "Project hash not found"
+    assert err["error"] == "Resource not found"
     assert err["detail"] == "Project hash does not have an associated job"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,11 +4,11 @@ import jsonschema
 from tests import setup
 import beebop.schemas
 import time
-from typing import Literal
+from typing import Literal, Callable
 
 
 def wait_until(
-    condition: callable, interval=300, timeout=10000
+    condition: Callable[[], bool], interval=300, timeout=10000
 ) -> Literal[True]:
     """
     Wait until a condition is met or timeout occurs.


### PR DESCRIPTION
The following refactor PR cleans up code in `app.py` + config related to setting up the flask app. 
The following is done in this PR
- Add `ResponseBody` and `ResponseError`, these are data classes that replace the untyped dictionaries we were using for the API body returns
-   Add badrequst error handler 
- update code where we were explicitly returning bad status codes and bodies. Now we just throw the error and let the exception handler return from api
- added logger for logging
- fix types in file `app.py`
- moved `get_args` to `config.py`
- added `get_environment()` which handles getting and validating these errors 
- replaced long if else with match case statements... this syntax on available python 3.10+ which is what should be used (used in docker images), so I've removed support for v3.9

I have also commented in the PR in some places to help make reviewing easier. 

Testing: 
no changes to logic has been made